### PR TITLE
fix typo in technology section

### DIFF
--- a/index.html
+++ b/index.html
@@ -287,7 +287,7 @@
             <a href="https://github.com/phenopackets/phenopacket-schema" target="_blank">
             protobuf schema
             </a>
-            this allows implementations to be automatically generated for many languages. The phenopacket-schema build
+            that allows implementations to be automatically generated for many languages. The phenopacket-schema build
             process automatically produces language bindings for Java, Python and C++.
           </p>
         </div>


### PR DESCRIPTION
Fixes #2.

In the technology section, the line

"Phenopackets are defined using a protobuf schema **_this_** allows implementations to be automatically generated for many languages."

was changed to 

"Phenopackets are defined using a protobuf schema **_that_** allows implementations to be automatically generated for many languages."