### PR TITLE
PhenoPackets -> Phenopackets

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,7 +157,7 @@
                   An open standard for sharing disease and phenotype information will improve
                   our ability to understand, diagnose, and treat both rare and common diseases.
 
-                  A PhenoPacket links detailed phenotype descriptions with disease, patient, and genetic information, enabling clinicians, biologists, and disease and drug researchers to build more complete models of disease.
+                  A Phenopacket links detailed phenotype descriptions with disease, patient, and genetic information, enabling clinicians, biologists, and disease and drug researchers to build more complete models of disease.
 
                   The standard is designed to encourage wide adoption and synergy between the people, organizations and systems that comprise the joint effort to address human disease and biological understanding.
                 </p>


### PR DESCRIPTION
I noticed this obsolete capitalization when I Googled Phenopackets ISO and it gave this summary for phenopackets.org:
> Phenopackets - Concepts and Technology http://phenopackets.org
A PhenoPacket links detailed phenotype descriptions with disease, patient, and genetic information, enabling clinicians, biologists, and disease and drug ...

I'm not sure where that summary actually comes from. I found the text in the middle of this page, but not sure how Google chose it as the summary text; it's possible that comes from somewhere else.